### PR TITLE
Basic Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use an official Python runtime as a base image
+FROM python:3.8-slim
+
+# Install software
+RUN apt-get update
+RUN apt-get install -y ffmpeg
+RUN pip3 install savify --upgrade
+
+# Define environment variable
+ENV SPOTIPY_CLIENT_ID=
+ENV SPOTIPY_CLIENT_SECRET=

--- a/bulk_docker_download.sh
+++ b/bulk_docker_download.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Information: The docker image has to be previously built and tagged with savify[:latest]
+# Use 'docker build -t savify .' inside the project directory to build the Docker container
+
+# Specify download location, use pwd for current directory
+location="`pwd`"
+
+# Specify playlists that should be downloaded
+declare -a playlists=(
+	"https://open.spotify.com/PLAYLIST_LINK"  # e.g. Playlist Name
+)
+
+# Set client ID and secret
+client_id=sampleid123
+client_secret=samplesecret123
+
+for playlist in "${playlists[@]}";
+do
+	echo "Downloading playlist: $playlist"
+	docker run --rm \
+		   -e SPOTIPY_CLIENT_ID=$client_id \
+		   -e SPOTIPY_CLIENT_SECRET=$client_secret \
+		   -v "$location":/download \
+		   savify \
+		   savify "$playlist" -o /download -g "%playlist%" -q best -f mp3 & # Use & for parallel downloading
+done

--- a/savify/savify.py
+++ b/savify/savify.py
@@ -80,6 +80,8 @@ class Savify:
                 result = self.spotify.search(query, query_type=Type.ALBUM)
             elif query_type == Type.PLAYLIST:
                 result = self.spotify.search(query, query_type=Type.PLAYLIST)
+            elif query_type == Type.ARTIST:
+                result = self.spotify.search(query, query_type=Type.ARTIST)
 
         return result
 

--- a/savify/types.py
+++ b/savify/types.py
@@ -5,6 +5,7 @@ class Type:
     TRACK = 'track'
     ALBUM = 'album'
     PLAYLIST = 'playlist'
+    ARTIST = 'artist'
 
 
 class Platform:


### PR DESCRIPTION
This PR adds a basic Dockerfile for building a savify image and a simple bash script for parallel bulk downloading of Spotify playlists.

Please note: the Dockerfile doesn't need to be changed. The environment variables for the client ID and secret are there for placeholder purposes.
You can choose whether you want them to be included in the self-built Docker image (not suggested!) or you want to pass them when running a container.