### PR TITLE
Adding basic Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use an official Python runtime as a base image
+FROM python:3.8-slim
+
+# Install any needed packages specified in requirements.txt
+RUN apt-get update && apt-get install -y git ffmpeg
+
+# Clone git repo
+RUN git clone https://github.com/LaurenceRawlings/savify
+WORKDIR /savify
+
+# Install dependencies and setup savify from source
+RUN pip3 install requests --upgrade
+RUN python3 setup.py install
+
+# Define environment variable as placeholder variables
+ENV SPOTIPY_CLIENT_ID=
+ENV SPOTIPY_CLIENT_SECRET=
+
+# Execute savify when container is started
+ENTRYPOINT ["/usr/local/bin/savify"]
+# Automatically print help if container is started without arguments
+CMD ["--help"]

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,14 @@ Using the Python module
 
 ``$ pip install -U savify``
 
+Build savify as Docker container
+--------------------------------
+
+Clone the repository and make sure you are in the root directory.
+Execute the following build command:
+
+``$ docker build -t savify:latest .``
+
 Usage
 =====
 
@@ -137,6 +145,30 @@ by default), from anywhere you can simply run:
 For help run:
 
 ``$ savify --help``
+
+Docker
+------
+
+Run savify inside a container which can also be attached to other 
+container's networks. This is handy if you want to run multiple instances
+of savify and/or want to use VPNs for downloading.
+You can use your self-built Docker image or the official one. Make sure to
+use the right Docker image name and tag.
+
+``$ docker run savify:latest``
+
+If no argument is specified, the container will print the help page. Simply
+append your arguments, make sure you mount a folder from your host so
+downloads are persistent (``-v``) - ``pwd`` is used to mount the current directory 
+you are in - and remove the container when done (``--rm``). You have to specify your 
+Spotify client ID and secret by using environment variables (``-e``):
+
+.. code-block:: bash
+
+    $ docker run --rm -v "`pwd`:/root/.local/share/Savify/downloads" \
+               -e SPOTIPY_CLIENT_ID=client_id \
+               -e SPOTIPY_CLIENT_SECRET=client_secret \
+               savify:latest "https://open.spotify.com/playlist/..."
 
 General usage
 ~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -169,6 +169,9 @@ Spotify client ID and secret by using environment variables (``-e``):
                -e SPOTIPY_CLIENT_ID=client_id \
                -e SPOTIPY_CLIENT_SECRET=client_secret \
                savify:latest "https://open.spotify.com/playlist/..."
+               
+If you want to preserve your logs, you can mount the logging directory by simply
+adding the following argument to the docker run command: ``-v "./logs:/root/.local/share/Savify/logs"``
 
 General usage
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Docker is handy if you want to be flexible and don't want to install Savify on your host machine. It's also useful if you want to download in parallel and with different networks.

That's why I created a Dockerfile which builds Savify from the GitHub repository and makes it easy to run Savify on your machine!

To make it even easier to use Savify in Docker we should publish an image of Savify in Docker Hub. The Dockerfile can be used to do so.