### PR TITLE
Docker: Not cloning repo but copy it to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 FROM python:3.8-slim
 
 # Install any needed packages specified in requirements.txt
-RUN apt-get update && apt-get install -y git ffmpeg
+RUN apt-get update && apt-get install -y ffmpeg
 
-# Clone git repo
-RUN git clone https://github.com/LaurenceRawlings/savify
+# Clone repo to container
+COPY . /savify
 WORKDIR /savify
 
 # Install dependencies and setup savify from source


### PR DESCRIPTION
Until now, the Docker image cloned the git repo to the container. This conflicts with best practices and takes the advantage of building a Docker image from forks or other branches. That is why I changed the Dockerfile to copying the source code to the container instead cloning it inside.

Another benefit is that git can be removed as dependency.