### PR TITLE
Changing default location for m3u files

### DIFF
--- a/savify/savify.py
+++ b/savify/savify.py
@@ -120,7 +120,7 @@ class Savify:
         if create_m3u and len(successful_jobs) > 0:
             playlist = safe_path_string(successful_jobs[0]['track'].playlist)
             m3u = f'#EXTM3U\n#PLAYLIST:{playlist}\n'
-            m3u_location = self.path_holder.get_download_dir() / f'{playlist}' / f'{playlist}.m3u'
+            m3u_location = self.path_holder.get_download_dir() / f'{playlist}.m3u'
 
             for job in successful_jobs:
                 track = job['track']


### PR DESCRIPTION
Defining `%playlist%/%playlist name%.m3u` as default location for m3u files is a problem when using a different grouping. The default location should be in the root download directory, making it independent of grouping and creating a standard for relative paths inside the m3u file.

Since creation of m3u playlists offers the ability to switch the grouping from `%playlist%` to `%artist%/%album%` as default (because most media servers expect this structure), having a `%playlist%` grouping is not needed anymore. Information regarding playlists are now kept in the m3u file like it should be.