### PR TITLE
Change multiple artist separator from , to /

### DIFF
--- a/savify/savify.py
+++ b/savify/savify.py
@@ -199,7 +199,7 @@ class Savify:
                 '-metadata', f'title={track.name}',
                 '-metadata', f'album={track.album_name}',
                 '-metadata', f'date={track.release_date}',
-                '-metadata', f'artist={", ".join(track.artists)}',
+                '-metadata', f'artist={"/".join(track.artists)}',
                 '-metadata', f'disc={track.disc_number}',
                 '-metadata', f'track={track.track_number}/{track.album_track_count}',
             ],


### PR DESCRIPTION
The standard for adding multiple artists to ID3 tags is using slashes and not commas. Right now, multiple artists can't be interpreted by most media players or media servers since they think that "artist 1, artist 2" is a completely new artist and has nothing to do with "artist 1" and "artist 2".