### PR TITLE
Refactor download_playlists to bulk_download

### DIFF
--- a/docker-scripts/bulk_download.sh
+++ b/docker-scripts/bulk_download.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script will download the playlists you specified in parallel. 
+# This script will download playlist, artists, albums or tracks you specified in parallel. 
 # Remove the & at the bottom of the for loop, if you want the script to download them sequentially.
 # When starting the script with bash download_playlists.sh, it will create n containers named 
 # savify_(last 12 characters of the playlist link) so you can resolve which containers downloads which playlist.
@@ -14,10 +14,10 @@ location="`pwd`"
 # Specify grouping schema
 grouping="%artist%/%album%"
 
-# Declare list with playlists to download, use comment to stay organized!
-declare -a playlists=(
-          "https://open.spotify.com/playlist"  # Playlist 1 name
-          "https://open.spotify.com/playlist"  # Playlist 2 name
+# Declare list with elements to download, use comment to stay organized!
+declare -a elements=(
+          "https://open.spotify.com/playlist"  # Element name
+          "https://open.spotify.com/album"     # Element name
 )
 
 # Set client ID and secret
@@ -25,12 +25,12 @@ client_id=sampleid123
 client_secret=samplesecret123
 
 # Specify the image you want Savify to run with
-version=laurencerawlings/savify:latest
+image_version=laurencerawlings/savify:latest
 
-for playlist in "${playlists[@]}";
+for element in "${elements[@]}";
 do
-( echo "Downloading playlist: $playlist"
-  id=${playlist: -8}
+( echo "Downloading element: $element"
+  id=${element: -8}
   vpn=$(docker ps -a --filter "name=vpn" --filter "health=healthy" --format "table {{.Names}}" | tail -n +2 | xargs shuf -n1 -e)
   if [ -z "$vpn" ]; then
         echo "No VPN found! Running without VPN!"
@@ -38,8 +38,8 @@ do
                 -e SPOTIPY_CLIENT_ID=$client_id \
                 -e SPOTIPY_CLIENT_SECRET=$client_secret \
                 -v "$location":/download \
-                $version \
-                "$playlist" -o /download -g "$grouping" -m
+                $image_version \
+                "$element" -o /download -g "$grouping" -m
   else
         echo "Using VPN: $vpn"
         docker run --rm -d --name "savify_${id//[^[:alnum:]]/}_$vpn" \
@@ -47,8 +47,8 @@ do
                 -e SPOTIPY_CLIENT_ID=$client_id \
                 -e SPOTIPY_CLIENT_SECRET=$client_secret \
                 -v "$location":/download \
-                $version \
-                "$playlist" -o /download -g "$grouping" -m
+                $image_version \
+                "$element" -o /download -g "$grouping" -m
   fi
-)
+) &
 done


### PR DESCRIPTION
The download_playlists script can be used for any type of download element. Instead of using several different scripts, using this one script is the preferred solution.