### PR TITLE
Updating Docker scripts to be modular and adding more settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,31 @@ Then run with:
 
 ``$ sh savify.sh "https://open.spotify.com/track/4Dju9g4NCz0LDxwcjonSvI"``
 
+You also have the option to quickstart using our docker script which have an integrated VPN-check
+to see if there are any VPN containers the script can connect to. The script is perfect for being
+scheduled with cron:
+
+.. code-block:: sh
+
+    $ wget https://github.com/laurencerawlings/savify/savify-docker-scripts.sh
+    $ unzip savify-docker-scripts.sh && rm savify-docker-scripts.sh
+    $ cd savify-docker-scripts/
+    
+You then have to edit the configuration file with your preferred text editor (we prefer nano),
+save it (Ctrl + X, Y for saving changes in nano) and rename it to ``config.sh``.
+
+.. code-block:: sh
+    
+    $ nano template.config.sh
+    $ mv template.config.sh config.sh
+    
+You can then run the script:
+
+.. code-block:: sh
+    
+    $ bash bulk-download.sh
+
+
 Spotify Application
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -246,7 +246,7 @@ scheduled with cron:
 
 .. code-block:: sh
 
-    $ wget https://github.com/laurencerawlings/savify//latest/download/savify-docker-scripts.zip
+    $ wget https://github.com/laurencerawlings/savify/latest/download/savify-docker-scripts.zip
     $ unzip savify-docker-scripts.zip && rm savify-docker-scripts.zip
     $ cd savify-docker-scripts/
     

--- a/README.rst
+++ b/README.rst
@@ -246,8 +246,8 @@ scheduled with cron:
 
 .. code-block:: sh
 
-    $ wget https://github.com/laurencerawlings/savify/savify-docker-scripts.sh
-    $ unzip savify-docker-scripts.sh && rm savify-docker-scripts.sh
+    $ wget https://github.com/laurencerawlings/savify//latest/download/savify-docker-scripts.zip
+    $ unzip savify-docker-scripts.zip && rm savify-docker-scripts.zip
     $ cd savify-docker-scripts/
     
 You then have to edit the configuration file with your preferred text editor (we prefer nano),

--- a/docker-scripts/bulk_download.sh
+++ b/docker-scripts/bulk_download.sh
@@ -1,54 +1,34 @@
 #!/bin/sh
-
 # This script will download playlist, artists, albums or tracks you specified in parallel. 
+# Make sure to customize the variables in the file "config.sh"
 # Remove the & at the bottom of the for loop, if you want the script to download them sequentially.
-# When starting the script with bash download_playlists.sh, it will create n containers named 
+# When starting the script with bash bulk_download.sh, it will create n containers named 
 # savify_(last 12 characters of the playlist link) so you can resolve which containers downloads which playlist.
 
-# Information: The docker image has to be previously built and tagged with savify[:dev]
-# Use 'docker build -t savify:dev .' inside the project directory to build the Docker container
-# Or use the Docker image provided in Docker Hub: laurencerawlings/savify:latest (recommended!)
+source "config.sh"
 
-# Specify download location, use pwd for current directory
-location="`pwd`"
-# Specify grouping schema
-grouping="%artist%/%album%"
-
-# Declare list with elements to download, use comment to stay organized!
-declare -a elements=(
-          "https://open.spotify.com/playlist"  # Element name
-          "https://open.spotify.com/album"     # Element name
-)
-
-# Set client ID and secret
-client_id=sampleid123
-client_secret=samplesecret123
-
-# Specify the image you want Savify to run with
-image_version=laurencerawlings/savify:latest
-
-for element in "${elements[@]}";
+for ELEMENT in "${ELEMENTS[@]}";
 do
-( echo "Downloading element: $element"
-  id=${element: -8}
-  vpn=$(docker ps -a --filter "name=vpn" --filter "health=healthy" --format "table {{.Names}}" | tail -n +2 | xargs shuf -n1 -e)
-  if [ -z "$vpn" ]; then
+( echo "Downloading element: $ELEMENT"
+  ID=${ELEMENT: -8}
+  VPN=$(docker ps -a --filter "name=vpn" --filter "health=healthy" --format "table {{.Names}}" | tail -n +2 | xargs shuf -n1 -e)
+  if [ -z "$VPN" ]; then
         echo "No VPN found! Running without VPN!"
-        docker run --rm -d --name "savify_${id//[^[:alnum:]]/}" \
-                -e SPOTIPY_CLIENT_ID=$client_id \
-                -e SPOTIPY_CLIENT_SECRET=$client_secret \
-                -v "$location":/download \
-                $image_version \
-                "$element" -o /download -g "$grouping" -m
+        docker run --rm -d --name "savify_${ID//[^[:alnum:]]/}" \
+                -e SPOTIPY_CLIENT_ID=$CLIENT_ID \
+                -e SPOTIPY_CLIENT_SECRET=$CLIENT_SECRET \
+                -v "$LOCATION":/download \
+                $IMAGE_VERSION \
+                "$ELEMENT" -o /download -g "$GROUPING" $OPTIONS
   else
-        echo "Using VPN: $vpn"
-        docker run --rm -d --name "savify_${id//[^[:alnum:]]/}_$vpn" \
-                --net=container:"$vpn" \
-                -e SPOTIPY_CLIENT_ID=$client_id \
-                -e SPOTIPY_CLIENT_SECRET=$client_secret \
-                -v "$location":/download \
-                $image_version \
-                "$element" -o /download -g "$grouping" -m
+        echo "Using VPN: $VPN"
+        docker run --rm -d --name "savify_${ID//[^[:alnum:]]/}_$VPN" \
+                --net=container:"$VPN" \
+                -e SPOTIPY_CLIENT_ID=$CLIENT_ID \
+                -e SPOTIPY_CLIENT_SECRET=$CLIENT_SECRET \
+                -v "$LOCATION":/download \
+                $IMAGE_VERSION \
+                "$ELEMENT" -o /download -g "$GROUPING" $OPTIONS
   fi
 ) &
 done

--- a/docker-scripts/template.config.sh
+++ b/docker-scripts/template.config.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# This file defines all variables needed for bulk downloading with Docker
+# Change the following settings, rename the file to "config.sh" 
+# and run the script with bash bulk_download.sh
+
+# Information: The docker image has to be previously built and tagged with savify[:dev]
+# Use 'docker build -t savify:dev .' inside the project directory to build the Docker container
+# Or use the Docker image provided in Docker Hub: laurencerawlings/savify:latest (recommended!)
+
+# Specify download location, use pwd for current directory
+LOCATION="`pwd`"
+# Specify grouping schema
+GROUPING="%artist%/%album%"
+
+# Declare list with elements to download, use comment to stay organized!
+declare -a ELEMENTS=(
+          "https://open.spotify.com/playlist"  # Element name
+          "https://open.spotify.com/album"     # Element name
+)
+
+# Set client ID and secret
+CLIENT_ID=sampleid123
+CLIENT_SECRET=samplesecret123
+
+# Specify options used for downloading
+# Recommendation: Use -m for auto-creating m3u playlist files
+# and -a for downloading full artist albums
+OPTIONS="-m -a"
+
+# Specify the image you want Savify to run with
+IMAGE_VERSION=laurencerawlings/savify:latest


### PR DESCRIPTION
Splitting the docker scripts into two parts: the runnable script and a config file, gives the user the ability to reuse configurations, even after updating them.

I added the option to customize savify-options and added `-a` as standard flag. This means downloading full artist discographies is now default when running as Docker script.