### PR TITLE
Fixed Issue #42 -- [BUG] Savify crashes when attempting to download a track whose title, author or album ends with an ellipsis. 

### DIFF
--- a/savify/logger.py
+++ b/savify/logger.py
@@ -32,14 +32,14 @@ class Logger:
         self.logger.error(traceback.format_exc())
 
     def debug(self, message):
-        self.logger.debug(message)
+        self.logger.debug(message.encode('utf8').decode('utf8'))
 
     def warning(self, message):
-        self.logger.warning(message)
+        self.logger.warning(message.encode('utf8').decode('utf8'))
 
     def error(self, message):
-        self.logger.error(message)
+        self.logger.error(message.encode('utf8').decode('utf8'))
 
     def info(self, message):
-        self.logger.info(message)
+        self.logger.info(message.encode('utf8').decode('utf8'))
 

--- a/savify/utils.py
+++ b/savify/utils.py
@@ -46,7 +46,7 @@ def safe_path_string(string):
         else:
             new_string = new_string + "_"
 
-    return re.sub('\.+$', '', new_string.rstrip())
+    return re.sub(r'\.+$', '', new_string.rstrip())
 
 
 class PathHolder:

--- a/savify/utils.py
+++ b/savify/utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 __all__ = ['PathHolder']
 
@@ -45,7 +46,7 @@ def safe_path_string(string):
         else:
             new_string = new_string + "_"
 
-    return new_string.rstrip()
+    return re.sub('\.+$', '', new_string.rstrip())
 
 
 class PathHolder:

--- a/savify/utils.py
+++ b/savify/utils.py
@@ -46,7 +46,7 @@ def safe_path_string(string):
         else:
             new_string = new_string + "_"
 
-    return re.sub(r'\.+$', '', new_string.rstrip())
+    return re.sub(r'\.+$', '', new_string.rstrip()).encode('utf8').decode('utf8')
 
 
 class PathHolder:


### PR DESCRIPTION
This pull request implements a fix for the issue outlined in Issue #42. This change uses regex to remove all trailing full-stops/periods from a string that is intended to be converted to a directory, via the `safe_path_string(string)` function in `utils.py`. 

Due to how _Savify_ saves metadata, the full-stops/periods remain in the metadata of the saved file. 