### PR TITLE
Expose language as a CLI option

### DIFF
--- a/savify/cli.py
+++ b/savify/cli.py
@@ -168,12 +168,14 @@ def guided_cli(type, quality, format, output, group, path, m3u, artist_albums, s
 @click.option('-m', '--m3u', is_flag=True, help='Create an M3U playlist file for your download.')
 @click.option('-a', '--artist-albums', is_flag=True, help='Download all artist songs and albums'
                                                           ', not just top 10 songs.')
+@click.option('-l', '--language', default=None, help='ISO-639 language code to be used for searching and tags applying.',
+              type=click.STRING)
 @click.option('--skip-cover-art', is_flag=True, help='Don\'t add cover art to downloaded song(s).')
 @click.option('--silent', is_flag=True, help='Hide all output to stdout, overrides verbosity level.')
 @click.option('-v', '--verbose', count=True, help='Change the log verbosity level. [-v, -vv]')
 @click.argument('query', required=False)
 @click.pass_context
-def main(ctx, type, quality, format, output, group, path, m3u, artist_albums, verbose, silent, query, skip_cover_art):
+def main(ctx, type, quality, format, output, group, path, m3u, artist_albums, verbose, silent, query, skip_cover_art, language):
     if not silent:
         show_banner()
         log_level = convert_log_level(verbose)
@@ -195,7 +197,8 @@ def main(ctx, type, quality, format, output, group, path, m3u, artist_albums, ve
 
     def setup(ffmpeg='ffmpeg'):
         return Savify(quality=quality, download_format=output_format, path_holder=path_holder, group=group,
-                      skip_cover_art=skip_cover_art, logger=logger, ffmpeg_location=ffmpeg, ydl_options=ydl_options)
+                      skip_cover_art=skip_cover_art, language=language, logger=logger, ffmpeg_location=ffmpeg, 
+                      ydl_options=ydl_options)
 
     def check_guided():
         if guided:

--- a/savify/savify.py
+++ b/savify/savify.py
@@ -47,8 +47,8 @@ def _progress(data) -> None:
 class Savify:
     def __init__(self, api_credentials=None, quality=Quality.BEST, download_format=Format.MP3,
                  group=None, path_holder: PathHolder = None, retry: int = 3,
-                 ydl_options: dict = None, skip_cover_art: bool = False, logger: Logger = None,
-                 ffmpeg_location: str = 'ffmpeg') -> None:
+                 ydl_options: dict = None, skip_cover_art: bool = False, language: str = None,
+                 logger: Logger = None, ffmpeg_location: str = 'ffmpeg') -> None:
 
         self.download_format = download_format
         self.ffmpeg_location = ffmpeg_location
@@ -69,9 +69,9 @@ class Savify:
             if not check_env():
                 raise SpotifyApiCredentialsNotSetError
 
-            self.spotify = Spotify()
+            self.spotify = Spotify(language=language)
         else:
-            self.spotify = Spotify(api_credentials=api_credentials)
+            self.spotify = Spotify(api_credentials=api_credentials, language=language)
 
         if not check_ffmpeg() and self.ffmpeg_location == 'ffmpeg':
             raise FFmpegNotInstalledError

--- a/savify/spotify.py
+++ b/savify/spotify.py
@@ -6,13 +6,14 @@ from .types import Type
 
 
 class Spotify:
-    def __init__(self, api_credentials=None) -> None:
+    def __init__(self, api_credentials=None, language: str = None) -> None:
         if api_credentials is None:
-            self.sp = spotipy.Spotify(client_credentials_manager=SpotifyClientCredentials())
+            self.sp = spotipy.Spotify(client_credentials_manager=SpotifyClientCredentials(), 
+                language=language)
         else:
             client_id, client_secret = api_credentials
             self.sp = spotipy.Spotify(client_credentials_manager=SpotifyClientCredentials(
-                client_id=client_id, client_secret=client_secret))
+                client_id=client_id, client_secret=client_secret), language=language)
 
     def search(self, query, query_type=Type.TRACK, artist_albums: bool = False) -> list:
         results = self.sp.search(q=query, limit=1, type=query_type)


### PR DESCRIPTION
The underlying spotipy library accepts a language tag to be used for fetching metadata. This PR exposes it to the CLI so that users can override the default behaviour which could be useful for Japanese or Chinese artists/albums/songs.