### PR TITLE
Download requested format instead of lossy compression

### DIFF
--- a/savify/savify.py
+++ b/savify/savify.py
@@ -209,7 +209,7 @@ class Savify:
         create_dir(output.parent)
 
         options = {
-            'format': 'bestaudio/best',
+            'format': f'bestaudio[acodec={self.download_format}]/bestaudio/best',
             'outtmpl': output_temp,
             'restrictfilenames': True,
             'ignoreerrors': True,


### PR DESCRIPTION
With this change, `savify` will instruct `youtube-dl` to prefer a download in the requested format, if available. For example, if the user requests `-f opus`, `youtube-dl` will download the opus original of the audio track, instead of downloading the `m4a` one and using `ffmpeg` for a lossy conversion to `opus`.