### PR TITLE
Add an Option to skip downloading certain Album Types when downloading Artists

### DIFF
--- a/savify/cli.py
+++ b/savify/cli.py
@@ -68,7 +68,7 @@ def validate_skip_album_types(_ctx, _param, value):
     if re.search(regex, str(value)) or value is None:
         return value
     else:
-        raise click.BadParameter('Group must be in the form x or x,x,x... where x in [single, album, compilation]')
+        raise click.BadParameter('Skip Album Type must be in the form x or x,x,x... where x in [single, album, compilation]')
 
 
 def guided_cli(type, quality, format, output, group, path, m3u, artist_albums, skip_cover_art, skip_album_types):
@@ -209,8 +209,6 @@ def main(ctx, type, quality, format, output, group, path, m3u, artist_albums, ve
     logger = Logger(path_holder.data_path, log_level)
     ydl_options = {ctx.args[i][2:]: ctx.args[i+1] for i in range(0, len(ctx.args), 2)}
     skip_album_types = [] if skip_album_types is None else skip_album_types.split(',')
-
-    print(skip_album_types)
 
     def setup(ffmpeg='ffmpeg'):
         return Savify(quality=quality, download_format=output_format, path_holder=path_holder, group=group,

--- a/savify/spotify.py
+++ b/savify/spotify.py
@@ -65,8 +65,6 @@ class Spotify:
                 if artist_albums:
                     albums = self._get_artist_albums(query)
                     tracks = list()
-                    print("excluding types")
-                    print(skip_album_types)
                     if len(skip_album_types) > 0:
                         albums = [ album for album in albums if not album["album_type"] in skip_album_types ]
                     for album in albums:

--- a/savify/spotify.py
+++ b/savify/spotify.py
@@ -14,8 +14,9 @@ class Spotify:
             self.sp = spotipy.Spotify(client_credentials_manager=SpotifyClientCredentials(
                 client_id=client_id, client_secret=client_secret))
 
-    def search(self, query, query_type=Type.TRACK, artist_albums: bool = False) -> list:
+    def search(self, query, query_type=Type.TRACK, artist_albums: bool = False, skip_album_types: list = []) -> list:
         results = self.sp.search(q=query, limit=1, type=query_type)
+        self.logger.info(f"Searching fro stuff")
         if len(results[f'{query_type}s']['items']) > 0:
             if query_type == Type.TRACK:
                 return [Track(results[f'{Type.TRACK}s']['items'][0])]
@@ -30,6 +31,8 @@ class Spotify:
                 if artist_albums:
                     albums = self._get_artist_albums(results[f'{Type.ARTIST}s']['items'][0]['id'])
                     tracks = list()
+                    if len(skip_album_types) > 0:
+                        albums = [ album for album in albums if not album["album_type"] in skip_album_types ]
                     for album in albums:
                         tracks.extend(_pack_album(self.sp.album(album['id'])))
 
@@ -41,7 +44,7 @@ class Spotify:
         else:
             return list()
 
-    def link(self, query, artist_albums: bool = False) -> list:
+    def link(self, query, artist_albums: bool = False, skip_album_types: list = []) -> list:
         try:
             if 'track' in query:
                 return [Track(self.sp.track(query))]
@@ -62,6 +65,10 @@ class Spotify:
                 if artist_albums:
                     albums = self._get_artist_albums(query)
                     tracks = list()
+                    print("excluding types")
+                    print(skip_album_types)
+                    if len(skip_album_types) > 0:
+                        albums = [ album for album in albums if not album["album_type"] in skip_album_types ]
                     for album in albums:
                         tracks.extend(_pack_album(self.sp.album(album['id'])))
 

--- a/savify/spotify.py
+++ b/savify/spotify.py
@@ -16,7 +16,6 @@ class Spotify:
 
     def search(self, query, query_type=Type.TRACK, artist_albums: bool = False, skip_album_types: list = []) -> list:
         results = self.sp.search(q=query, limit=1, type=query_type)
-        self.logger.info(f"Searching fro stuff")
         if len(results[f'{query_type}s']['items']) > 0:
             if query_type == Type.TRACK:
                 return [Track(results[f'{Type.TRACK}s']['items'][0])]


### PR DESCRIPTION
Add an Option to skip downloading any album type such as singles or compilations.

When downloading an Artists discography, most of what was downloaded was singles or compilations. I wanted an option to be able to choose which album types to download. For example i just wanted the full albums of an artist and what I got was 2 full albums and 15 singles that were in those albums.

Some Artists have a lot of singles or 2 song compilations.

See Simply for an example: 
https://open.spotify.com/artist/5xazQSF69sfMYkAu1758DS/discography/all

If you see anything you want changed hit me up.