### PR TITLE
Fixed 403 Errors and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /savify
 # Install dependencies and setup savify from source
 RUN pip3 install requests --upgrade
 RUN python3 setup.py install
+RUN pip3 install yt_dlp
 
 # Define environment variable as placeholder variables
 ENV SPOTIPY_CLIENT_ID=

--- a/savify/savify.py
+++ b/savify/savify.py
@@ -12,7 +12,7 @@ from urllib.error import URLError
 import validators
 import tldextract
 import requests
-from youtube_dl import YoutubeDL
+from yt_dlp import YoutubeDL
 from ffmpy import FFmpeg, FFRuntimeError
 
 from .utils import PathHolder, safe_path_string, check_env, check_ffmpeg, check_file, create_dir, clean


### PR DESCRIPTION
YoutubeDL is out of date. The latest yt_dlp works with current codebase. I made the changes and was able to create an updated Docker image that works. I no longer get any errors from YouTube-dl 